### PR TITLE
Require SQL Comment Hint so that schema manager (migrations) works correctly

### DIFF
--- a/src/ChronosDateTimeType.php
+++ b/src/ChronosDateTimeType.php
@@ -38,4 +38,12 @@ class ChronosDateTimeType extends DateTimeType
 
         return Chronos::instance($dateTime);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/ChronosDateTimeTzType.php
+++ b/src/ChronosDateTimeTzType.php
@@ -38,4 +38,12 @@ class ChronosDateTimeTzType extends DateTimeTzType
 
         return Chronos::instance($dateTime);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/src/ChronosDateType.php
+++ b/src/ChronosDateType.php
@@ -39,4 +39,12 @@ class ChronosDateType extends DateType
 
         return Date::instance($dateTime);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
These types inherit from pre-existing Doctrine DBAL types (`DateType`, `DateTimeType`, etc).

When the Doctrine schema comparator runs, it always thinks that the type in the database is the base type (`DateTime`, etc).  Thus, Doctrine migrations always creates an `ALTER TABLE` statement even when the column definition has not changed.

The solution to this, according to the Doctrine documentation, is to use SQL Comment hints so that Doctrine knows exactly what type of column this is: https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Types/Type.php#L318