### PR TITLE
Add return types to remove deprecation warning

### DIFF
--- a/src/ChronosDateTimeType.php
+++ b/src/ChronosDateTimeType.php
@@ -28,7 +28,7 @@ class ChronosDateTimeType extends DateTimeType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Chronos
     {
         if ($value === null) {
             return null;

--- a/src/ChronosDateTimeTzType.php
+++ b/src/ChronosDateTimeTzType.php
@@ -28,7 +28,7 @@ class ChronosDateTimeTzType extends DateTimeTzType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Chronos
     {
         if ($value === null) {
             return null;

--- a/src/ChronosDateType.php
+++ b/src/ChronosDateType.php
@@ -9,7 +9,6 @@
 namespace Warhuhn\Doctrine\DBAL\Types;
 
 
-use Cake\Chronos\Chronos;
 use Cake\Chronos\Date;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateType;
@@ -29,7 +28,7 @@ class ChronosDateType extends DateType
     /**
      * {@inheritDoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Date
     {
         if ($value === null) {
             return null;


### PR DESCRIPTION
With Symfony 5.4 I got the following deprecation warnings

>Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Warhuhn\Doctrine\DBAL\Types\ChronosDateType" now to avoid errors or add an explicit @return annotation to suppress this message.

>Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Warhuhn\Doctrine\DBAL\Types\ChronosDateTimeType" now to avoid errors or add an explicit @return annotation to suppress this message.

I've added the appropriate return types to remove these messages.