### PR TITLE
replace "Date::instance($value)" with "new Date($value)"

### DIFF
--- a/src/ChronosDateType.php
+++ b/src/ChronosDateType.php
@@ -36,7 +36,7 @@ class ChronosDateType extends DateType
 
         $dateTime = parent::convertToPHPValue($value, $platform);
 
-        return Date::instance($dateTime);
+        return new Date($dateTime);
     }
 
     /**


### PR DESCRIPTION
Calling toChronosDate::instance() has been deprecated and will be removed on 3.0

See https://github.com/cakephp/chronos/blob/3cbb9e2d8af1065c7189e1dc3f4fa641e797719f/src/Traits/FactoryTrait.php#L44C37-L44C37