### PR TITLE
Update DBAL 4.0

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4']
         dependency-version: ['prefer-lowest', 'prefer-stable']
 
     name: Test ${{ matrix.os }} PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,13 +1,14 @@
 name: Run unit tests
 
 on:
+  workflow_dispatch:
   pull_request:
     types: ['opened', 'synchronize', 'reopened']
   push:
     branches: ['master']
-  schedule:
+  #schedule:
     # run once every month
-    - cron: '0 12 15 * *'
+    #- cron: '0 12 15 * *'
 
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        php: ['7.3', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4']
         dependency-version: ['prefer-lowest', 'prefer-stable']
 
     name: Test ${{ matrix.os }} PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/README.md
+++ b/README.md
@@ -36,34 +36,29 @@ doctrine:
            chronos_datetimetz: Warhuhn\Doctrine\DBAL\Types\ChronosDateTimeTzType
 ```
 
-## Usage in Doctrine ORM
+## Usage in Doctrine ORM 3.0
 
 ```php
 <?php
 
+namespace Warhuhn\Doctrine\DBAL\Types;
+
+use Cake\Chronos\Chronos;
+use Cake\Chronos\ChronosDate;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity]
 class Example
 {
-    /**
-     * @var \Cake\Chronos\ChronosDate 
-     * @ORM\Column(type="chronos_date")
-     */
-    private $date;
-    
-    /**
-     * @var \Cake\Chronos\Chronos
-     * @ORM\Column(type="chronos_datetime")
-     */
-    private $dateTime;
-    
-    /**
-     * @var \Cake\Chronos\Chronos
-     * @ORM\Column(type="chronos_datetimetz")
-     */
-    private $dateTimeTz;
+
+    #[ORM\Column(type: 'chronos_date')]
+    private ChronosDate $date;
+
+    #[ORM\Column(type: 'chronos_datetime')]
+    private Chronos $dateTime;
+
+    #[ORM\Column(type: 'chronos_datetimetz')]
+    private Chronos $dateTimeTz;
+
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
   },
   "require": {
     "php": ">=8.1",
-    "cakephp/chronos": "^3.0.2",
+    "cakephp/chronos": "^3.3",
     "doctrine/dbal": "^4.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.0"
+    "phpunit/phpunit": "^10.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "source": "https://github.com/warhuhn/chronos-php"
   },
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "cakephp/chronos": "^3.3",
     "doctrine/dbal": "^4.3"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "source": "https://github.com/warhuhn/chronos-php"
   },
   "require": {
-    "php": ">=7.3",
-    "cakephp/chronos": "^2.4|^3.0.2",
-    "doctrine/dbal": "^2.10|^3.0"
+    "php": ">=8.1",
+    "cakephp/chronos": "^3.0.2",
+    "doctrine/dbal": "^4.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "doctrine/dbal": "^4.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.3"
+    "phpunit/phpunit": "^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php" colors="true" backupGlobals="false">
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" backupGlobals="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/ChronosDateTimeTzType.php
+++ b/src/ChronosDateTimeTzType.php
@@ -5,11 +5,21 @@ namespace Warhuhn\Doctrine\DBAL\Types;
 
 use Cake\Chronos\Chronos;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\DateTimeTzType;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use Doctrine\DBAL\Types\Type;
+use Warhuhn\Doctrine\DBAL\Types\Traits\ExtendsDoctrineType;
 
-class ChronosDateTimeTzType extends DateTimeTzType
+class ChronosDateTimeTzType extends Type
 {
+    use ExtendsDoctrineType;
+
     const CHRONOS_DATETIMETZ = 'chronos_datetimetz';
+
+    public function __construct()
+    {
+        $this->type = new DateTimeTzImmutableType();
+    }
 
     /**
      * {@inheritDoc}
@@ -22,22 +32,44 @@ class ChronosDateTimeTzType extends DateTimeTzType
     /**
      * {@inheritDoc}
      */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof Chronos) {
+            return $value->format($platform->getDateTimeTzFormatString());
+        }
+
+        throw InvalidType::new(
+            $value,
+            static::class,
+            ['null', Chronos::class],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?Chronos
     {
         if ($value === null) {
             return null;
         }
 
-        $dateTime = parent::convertToPHPValue($value, $platform);
+        $dateTime = $this->type->convertToPHPValue($value, $platform);
+
+        file_put_contents(__DIR__ . '/output.txt', var_export([
+                'platform' => basename(get_class($platform)),
+                'platform_format' => $platform->getDateTimeTzFormatString(),
+                'value' => $value,
+                'date' => $dateTime->format(DATE_ATOM),
+                'offset' => $dateTime->getOffset(),
+                'tz' => $dateTime->getTimezone(),
+                'format' => $platform->getDateTimeTzFormatString(),
+            ], true) . PHP_EOL . PHP_EOL, FILE_APPEND);
 
         return Chronos::instance($dateTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        return true;
     }
 }

--- a/src/ChronosDateTimeTzType.php
+++ b/src/ChronosDateTimeTzType.php
@@ -60,16 +60,6 @@ class ChronosDateTimeTzType extends Type
 
         $dateTime = $this->type->convertToPHPValue($value, $platform);
 
-        file_put_contents(__DIR__ . '/output.txt', var_export([
-                'platform' => basename(get_class($platform)),
-                'platform_format' => $platform->getDateTimeTzFormatString(),
-                'value' => $value,
-                'date' => $dateTime->format(DATE_ATOM),
-                'offset' => $dateTime->getOffset(),
-                'tz' => $dateTime->getTimezone(),
-                'format' => $platform->getDateTimeTzFormatString(),
-            ], true) . PHP_EOL . PHP_EOL, FILE_APPEND);
-
         return Chronos::instance($dateTime);
     }
 }

--- a/src/Traits/ExtendsDoctrineType.php
+++ b/src/Traits/ExtendsDoctrineType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Warhuhn\Doctrine\DBAL\Types\Traits;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Shares often used methods
+ */
+trait ExtendsDoctrineType
+{
+    protected Type $type;
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $this->type->getSQLDeclaration($column, $platform);
+    }
+}

--- a/tests/ChronosDateTimeTypeTest.php
+++ b/tests/ChronosDateTimeTypeTest.php
@@ -4,20 +4,22 @@ namespace Tests\Warhuhn\Doctrine\DBAL\Types;
 
 use Cake\Chronos\Chronos;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MariaDB1010Platform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Tests\Warhuhn\Doctrine\DBAL\Types\Traits\HasPlatformDataProvider;
 use Warhuhn\Doctrine\DBAL\Types\ChronosDateTimeType;
 
 class ChronosDateTimeTypeTest extends TestCase
 {
-
-	/**
-	 * @var AbstractPlatform
-	 */
-    private $platform;
-
     /**
      * @var Type
      */
@@ -31,42 +33,61 @@ class ChronosDateTimeTypeTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform = $this->getPlatformMock();
         $this->type = Type::getType('chronos_datetime');
     }
 
-
-	public function testInvalidDateConversion(): void
+    /**
+     * @dataProvider providePlatform
+     */
+	public function testInvalidDateConversion(AbstractPlatform $platform): void
 	{
 		$this->expectException(ConversionException::class);
-		$this->type->convertToPHPValue('aaaa', $this->platform);
+
+		$this->type->convertToPHPValue('aaaa', $platform);
     }
 
-    public function testConvertToPhpValue(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testConvertToPhpValue(AbstractPlatform $platform, $time, $dbTime): void
     {
-        $obj = $this->type->convertToPHPValue('2016-11-05 07:54:02', $this->platform);
+        $obj = $this->type->convertToPHPValue($dbTime, $platform);
 
         static::assertInstanceOf(Chronos::class, $obj);
-        static::assertEquals('2016-11-05 07:54:02', $obj->format('Y-m-d H:i:s'));
+        static::assertEquals($time, $obj->format('Y-m-d H:i:s'));
     }
 
-    public function testConvertToDatabaseValue(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testConvertToDatabaseValue(AbstractPlatform $platform, $time, $dbTime): void
     {
-        $value = $this->type->convertToDatabaseValue(new Chronos('2016-11-05 07:54:02'), $this->platform);
+        $value = $this->type->convertToDatabaseValue(new Chronos($time), $platform);
 
-        static::assertEquals('2016-11-05 07:54:02', $value);
+        static::assertEquals($dbTime, $value);
     }
 
-    public function testNull(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testNull(AbstractPlatform $platform): void
     {
-        $obj = $this->type->convertToPHPValue(null, $this->platform);
+        $obj = $this->type->convertToPHPValue(null, $platform);
 
         static::assertNull($obj);
     }
-    private function getPlatformMock(): MockObject
-	{
-        return $this->getMockBuilder(AbstractPlatform::class)
-            ->getMockForAbstractClass();
-    }
 
+    public function providePlatform(): array
+    {
+        return [
+            'db2'         => [new DB2Platform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'mariadb1010' => [new MariaDB1010Platform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'mariadb'     => [new MariaDBPlatform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'mysql'       => [new MySQLPlatform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'oracle'      => [new OraclePlatform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'pgsql'       => [new PostgreSQLPlatform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'sqlite'      => [new SQLitePlatform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],
+            'sqlsrv'      => [new SQLServerPlatform, '2016-11-05 07:54:02', '2016-11-05 07:54:02.000000'],
+        ];
+    }
 }

--- a/tests/ChronosDateTimeTypeTest.php
+++ b/tests/ChronosDateTimeTypeTest.php
@@ -77,7 +77,7 @@ class ChronosDateTimeTypeTest extends TestCase
         static::assertNull($obj);
     }
 
-    public function providePlatform(): array
+    public static function providePlatform(): array
     {
         return [
             'db2'         => [new DB2Platform, '2016-11-05 07:54:02', '2016-11-05 07:54:02'],

--- a/tests/ChronosDateTimeTzTypeTest.php
+++ b/tests/ChronosDateTimeTzTypeTest.php
@@ -94,7 +94,7 @@ class ChronosDateTimeTzTypeTest extends TestCase
         static::assertNull($obj);
     }
 
-    public function providePlatform(): array
+    public static function providePlatform(): array
     {
         return [
             'db2'         => [new DB2Platform,         '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02',              ],

--- a/tests/ChronosDateTimeTzTypeTest.php
+++ b/tests/ChronosDateTimeTzTypeTest.php
@@ -4,20 +4,22 @@ namespace Tests\Warhuhn\Doctrine\DBAL\Types;
 
 use Cake\Chronos\Chronos;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MariaDB1010Platform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Tests\Warhuhn\Doctrine\DBAL\Types\Traits\HasPlatformDataProvider;
 use Warhuhn\Doctrine\DBAL\Types\ChronosDateTimeTzType;
 
 class ChronosDateTimeTzTypeTest extends TestCase
 {
-
-	/**
-	 * @var AbstractPlatform
-	 */
-    private $platform;
-
     /**
      * @var Type
      */
@@ -31,58 +33,78 @@ class ChronosDateTimeTzTypeTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform = $this->getPlatformMock();
         $this->type = Type::getType('chronos_datetimetz');
     }
 
-
-	public function testInvalidDateConversion(): void
+    /**
+     * @dataProvider providePlatform
+     */
+	public function testInvalidDateConversion(AbstractPlatform $platform): void
     {
-        $this->platform
-            ->method('getDateTimeTzFormatString')
-            ->willReturn('Y-m-d H:i:sO');
-
 		$this->expectException(ConversionException::class);
-		$this->type->convertToPHPValue('aaaa', $this->platform);
+		$this->type->convertToPHPValue('aaaa', $platform);
     }
 
-    public function testConvertToPhpValue(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testConvertToPhpValue(AbstractPlatform $platform, $time, $dbTime): void
     {
-        $this->platform
-            ->method('getDateTimeTzFormatString')
-            ->willReturn('Y-m-d H:i:sO');
+        // Some platforms don't have a tz format string that actually saves the timezone, and I am too lazy to implement different tests for that.
+        if ($platform->getDateTimeFormatString() === $platform->getDateTimeTzFormatString()) {
+            static::markTestSkipped(sprintf('DBAL Platform %s does not support datetime with timezones', basename(get_class($platform))));
+        }
 
         /** @var Chronos $obj */
-        $obj = $this->type->convertToPHPValue('2016-11-05 07:54:02+0400', $this->platform);
+        $obj = $this->type->convertToPHPValue($dbTime, $platform);
 
         static::assertInstanceOf(Chronos::class, $obj);
-        static::assertEquals('2016-11-05 07:54:02+0400', $obj->format('Y-m-d H:i:sO'));
+
+        static::assertEquals($time, $obj->format('Y-m-d H:i:sO'));
         static::assertEquals(14400, $obj->getOffset());
     }
 
-    public function testConvertToDatabaseValue(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testConvertToDatabaseValue(AbstractPlatform $platform, $time, $dbTime): void
     {
-        $this->platform
-            ->method('getDateTimeTzFormatString')
-            ->willReturn('Y-m-d H:i:sO');
+        // Some platforms don't have a tz format string that actually saves the timezone, and I am too lazy to implement different tests for that.
+        if ($platform->getDateTimeFormatString() === $platform->getDateTimeTzFormatString()) {
+            static::markTestSkipped(sprintf('DBAL Platform %s does not support datetime with timezones', basename(get_class($platform))));
+        }
 
-        $value = $this->type->convertToDatabaseValue(new Chronos('2016-11-05 07:54:02+0400'), $this->platform);
+        $value = $this->type->convertToDatabaseValue(new Chronos($time), $platform);
 
-        static::assertEquals('2016-11-05 07:54:02+0400', $value);
+        static::assertEquals($dbTime, $value);
     }
 
-    public function testNull(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testNull(AbstractPlatform $platform): void
     {
-        $obj = $this->type->convertToPHPValue(null, $this->platform);
+        // Some platforms don't have a tz format string that actually saves the timezone, and I am too lazy to implement different tests for that.
+        if ($platform->getDateTimeFormatString() === $platform->getDateTimeTzFormatString()) {
+            static::markTestSkipped(sprintf('DBAL Platform %s does not support datetime with timezones', basename(get_class($platform))));
+        }
+
+        $obj = $this->type->convertToPHPValue(null, $platform);
 
         static::assertNull($obj);
     }
 
-    private function getPlatformMock(): MockObject
+    public function providePlatform(): array
     {
-        return $this->getMockBuilder(AbstractPlatform::class)
-            ->onlyMethods(['getDateTimeTzFormatString'])
-            ->getMockForAbstractClass();
+        return [
+            'db2'         => [new DB2Platform,         '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02',              ],
+            'mariadb1010' => [new MariaDB1010Platform, '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02',              ],
+            'mariadb'     => [new MariaDBPlatform,     '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02',              ],
+            'mysql'       => [new MySQLPlatform,       '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02',              ],
+            'oracle'      => [new OraclePlatform,      '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02+04:00',        ],
+            'pgsql'       => [new PostgreSQLPlatform,  '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02+0400',         ],
+            'sqlite'      => [new SQLitePlatform,      '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02',              ],
+            'sqlsrv'      => [new SQLServerPlatform,   '2016-11-05 07:54:02+0400', '2016-11-05 07:54:02.000000 +04:00',],
+        ];
     }
-
 }

--- a/tests/ChronosDateTypeTest.php
+++ b/tests/ChronosDateTypeTest.php
@@ -75,7 +75,7 @@ class ChronosDateTypeTest extends TestCase
         static::assertNull($obj);
     }
 
-    public function providePlatform(): array
+    public static function providePlatform(): array
     {
         return [
             'db2'         => [new DB2Platform, '2016-11-05', '2016-11-05'],

--- a/tests/ChronosDateTypeTest.php
+++ b/tests/ChronosDateTypeTest.php
@@ -2,23 +2,23 @@
 
 namespace Tests\Warhuhn\Doctrine\DBAL\Types;
 
-use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\MariaDB1010Platform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Warhuhn\Doctrine\DBAL\Types\ChronosDateType;
 
 class ChronosDateTypeTest extends TestCase
 {
-
-	/**
-	 * @var AbstractPlatform
-	 */
-    private $platform;
-
     /**
      * @var Type
      */
@@ -32,43 +32,60 @@ class ChronosDateTypeTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform = $this->getPlatformMock();
         $this->type = Type::getType('chronos_date');
     }
 
-
-	public function testInvalidDateConversion(): void
+    /**
+     * @dataProvider providePlatform
+     */
+	public function testInvalidDateConversion(AbstractPlatform $platform): void
     {
 		$this->expectException(ConversionException::class);
-		$this->type->convertToPHPValue('aaaa', $this->platform);
+		$this->type->convertToPHPValue('aaaa', $platform);
     }
 
-    public function testConvertToPhpValue(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testConvertToPhpValue(AbstractPlatform $platform, $date, $dbDate): void
     {
-        $obj = $this->type->convertToPHPValue('2016-11-05', $this->platform);
+        $obj = $this->type->convertToPHPValue($dbDate, $platform);
 
         static::assertInstanceOf(ChronosDate::class, $obj);
-        static::assertEquals('2016-11-05', $obj->format('Y-m-d'));
+        static::assertEquals($date, $obj->format('Y-m-d'));
     }
 
-    public function testConvertToDatabaseValue(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testConvertToDatabaseValue(AbstractPlatform $platform, $date, $dbDate): void
     {
-        $value = $this->type->convertToDatabaseValue(new ChronosDate('2016-11-05'), $this->platform);
+        $value = $this->type->convertToDatabaseValue(new ChronosDate($date), $platform);
 
-        static::assertEquals('2016-11-05', $value);
+        static::assertEquals($dbDate, $value);
     }
 
-    public function testNull(): void
+    /**
+     * @dataProvider providePlatform
+     */
+    public function testNull(AbstractPlatform $platform): void
     {
-        $obj = $this->type->convertToPHPValue(null, $this->platform);
+        $obj = $this->type->convertToPHPValue(null, $platform);
 
         static::assertNull($obj);
     }
 
-    private function getPlatformMock(): MockObject
+    public function providePlatform(): array
     {
-        return $this->getMockBuilder(AbstractPlatform::class)
-            ->getMockForAbstractClass();
+        return [
+            'db2'         => [new DB2Platform, '2016-11-05', '2016-11-05'],
+            'mariadb1010' => [new MariaDB1010Platform, '2016-11-05', '2016-11-05'],
+            'mariadb'     => [new MariaDBPlatform, '2016-11-05', '2016-11-05'],
+            'mysql'       => [new MySQLPlatform, '2016-11-05', '2016-11-05'],
+            'oracle'      => [new OraclePlatform, '2016-11-05', '2016-11-05 00:00:00'],
+            'pgsql'       => [new PostgreSQLPlatform, '2016-11-05', '2016-11-05'],
+            'sqlite'      => [new SQLitePlatform, '2016-11-05', '2016-11-05'],
+            'sqlsrv'      => [new SQLServerPlatform, '2016-11-05', '2016-11-05'],
+        ];
     }
-
 }


### PR DESCRIPTION
* Update & Require DBAL to 4.0
* Require Chronos 3.0 or Higher
* Drop all currently EOL PHP Versions (< 8.1)
* Update PHPUnit to 10.0 and fix all the deprecations
* Test against the Platform implementations instead of an AbstractMock

This will be a greatly breaking change and require a new major version.